### PR TITLE
 modules in SpeechSyntehesizer.ios.js is native to react-native

### DIFF
--- a/SpeechSynthesizer.ios.js
+++ b/SpeechSynthesizer.ios.js
@@ -4,8 +4,9 @@
  */
 'use strict';
 
-var NativeSpeechSynthesizer = require('NativeModules').SpeechSynthesizer;
-var invariant = require('invariant');
+var NativeSpeechSynthesizer = require('react-native').NativeModules;
+// var invariant = require('invariant');
+var invariant = require('react-native').invariant;
 
 /**
  * High-level docs for the SpeechSynthesizer iOS API can be written here.


### PR DESCRIPTION
#8 The modules you're requiring in SpeechSyntehesizer.ios.js are offered by react-native. Requiring NativeModules & invariant individually throws an error.  

  