### PR TITLE
Remove unused invariant, properly use NativeModules

### DIFF
--- a/SpeechSynthesizer.ios.js
+++ b/SpeechSynthesizer.ios.js
@@ -4,8 +4,9 @@
  */
 'use strict';
 
-var NativeSpeechSynthesizer = require('NativeModules').SpeechSynthesizer;
-var invariant = require('invariant');
+var React = require('react-native');
+var { NativeModules } = React;
+var NativeSpeechSynthesizer = NativeModules.SpeechSynthesizer;
 
 /**
  * High-level docs for the SpeechSynthesizer iOS API can be written here.


### PR DESCRIPTION
From the looks of it, `invariant` is not used in this repo. 

Also, there is an error with the way `NativeModules` is loaded. Without this change, I'm seeing the error:

```
2015-12-05 22:07:56.554 [error][tid:main] Unable to resolve module NativeModules from /my/pathnode_modules/react-native-speech/SpeechSynthesizer.ios.js: Invalid directory /Users/node_modules/NativeModules
```
