### PR TITLE
Fixing error which disabled speech after calling Speech.stop

### DIFF
--- a/SpeechSynthesizer.m
+++ b/SpeechSynthesizer.m
@@ -61,6 +61,7 @@ RCT_EXPORT_METHOD(stopSpeakingAtBoundary)
 {
     if (self.synthesizer) {
         [self.synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+        self.synthesizer = nil;
     }
 }
 


### PR DESCRIPTION
Since `self.synthesizer` isn't reset efter calling `Speech.stop`, it won't work when calling `Speech.speak` afterwards.